### PR TITLE
update for incidence 1.4.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,11 +12,12 @@ Suggests:
     testthat,
     roxygen2, 
     outbreaks, 
-    incidence,
+    incidence (>= 1.4.1),
     knitr,
     rmarkdown
 Imports: digest, distcrete, stringi
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.0
+Remotes: reconhub/incidence
 URL: http://www.repidemicsconsortium.org/epitrix
 BugReports: https://github.com/reconhub/epitrix/issues
 VignetteBuilder: knitr

--- a/R/r_to_R0_Wallinga_Lipsitch.R
+++ b/R/r_to_R0_Wallinga_Lipsitch.R
@@ -44,7 +44,7 @@
 #'     f
 #'     plot(i[1:150], fit = f)
 #'
-#'     R0 <- lm2R0_sample(f$lm, w)
+#'     R0 <- lm2R0_sample(f$model, w)
 #'     hist(R0, col = "grey", border = "white", main = "Distribution of R0")
 #'     summary(R0)
 #'   }

--- a/man/r2R0.Rd
+++ b/man/r2R0.Rd
@@ -64,7 +64,7 @@ if (require(distcrete)) {
     f
     plot(i[1:150], fit = f)
 
-    R0 <- lm2R0_sample(f$lm, w)
+    R0 <- lm2R0_sample(f$model, w)
     hist(R0, col = "grey", border = "white", main = "Distribution of R0")
     summary(R0)
   }

--- a/vignettes/epitrix.Rmd
+++ b/vignettes/epitrix.Rmd
@@ -137,7 +137,7 @@ R0 values compatible with a model fit:
 
 ```{r sample_R0}
 
-R0_val <- lm2R0_sample(f$lm, si$d(1:100), n = 100)
+R0_val <- lm2R0_sample(f$model, si$d(1:100), n = 100)
 head(R0_val)
 hist(R0_val, col = "grey", border = "white")
 


### PR DESCRIPTION
I'm about to submit incidence 1.4.1 to CRAN, but this will break a couple of examples in epitrix. This update helps avoid this.

Note: you will have to remove the `Remotes:` field in the DESCRIPTION file for this to work.