### PR TITLE
Update DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,5 +35,5 @@ Imports:
 RoxygenNote: 7.2.3
 Config/testthat/edition: 3
 URL: http://www.repidemicsconsortium.org/epitrix/
-BugReports: https://github.com/reconhub/epitrix/issues
+BugReports: https://github.com/reconhub/epitrix/issues, https://github.com/reconhub/epitrix/
 VignetteBuilder: knitr


### PR DESCRIPTION
The github URL is added to the description. This will give cran users awareness of the GitHub location.

For an example see https://github.com/tidyverse/dplyr/blob/main/DESCRIPTION